### PR TITLE
Fix the flash type to be alert and set the error message to devise

### DIFF
--- a/app/controllers/alchemy/base_controller.rb
+++ b/app/controllers/alchemy/base_controller.rb
@@ -60,7 +60,7 @@ module Alchemy
     end
 
     def handle_redirect_for_user
-      flash[:warning] = Alchemy.t('You are not authorized')
+      flash[:alert] = ::I18n.t('devise.failure.unauthenticated', default: Alchemy.t('You are not authorized'))
       if can?(:index, :alchemy_admin_dashboard)
         redirect_or_render_notice
       else


### PR DESCRIPTION
Customizing the unauthorized error to alert and use the message from devise. If the translation for devise is missing, it will fall back to alchemy error message.

![screen shot 2560-11-27 at 12 32 45 pm](https://user-images.githubusercontent.com/6965195/33252186-2ee9a9e4-d36f-11e7-9859-d50a44650291.png)
