### PR TITLE
[#159295940] Allow only admin to access elements index

### DIFF
--- a/app/controllers/alchemy/admin/elements_controller.rb
+++ b/app/controllers/alchemy/admin/elements_controller.rb
@@ -4,9 +4,11 @@ module Alchemy
   module Admin
     class ElementsController < Alchemy::Admin::BaseController
       before_action :load_element, only: [:update, :trash, :fold, :publish]
-      authorize_resource class: Alchemy::Element
+      authorize_resource class: Alchemy::Element, except: [:index]
 
       def index
+        authorize! :index, :alchemy_admin_elements
+
         @page = Page.find(params[:page_id])
         @cells = @page.cells
         if @cells.blank?

--- a/lib/alchemy/permissions.rb
+++ b/lib/alchemy/permissions.rb
@@ -95,7 +95,8 @@ module Alchemy
           :alchemy_admin_pages,
           :alchemy_admin_pictures,
           :alchemy_admin_tags,
-          :alchemy_admin_users
+          :alchemy_admin_users,
+          :alchemy_admin_elements
         ]
 
         # Controller actions


### PR DESCRIPTION
**What Happened**

Alchemy element index page can be accessed any user roles even anonymous user. Because of `elements_controller` in admin is authorize using `Alchemy::Element` which allows any user to see so it any user can access index of element controller. 
Solved by authorize admin instead of `Alchemy::Element` in elements index.

**Insight**

Other Alchemy admin page such as `pages_controller`, `dashboard_controller` is authorized by defining class which allow only admin.

```ruby
.../alchemy_cms/app/controllers/alchemy/admin/dashboard_controller.rb
module Alchemy
  module Admin
    class DashboardController < Alchemy::Admin::BaseController
      authorize_resource class: :alchemy_admin_dashboard

      def index
        ...
      end
    end
  end
end
```
But in `elements_controller` is authorize by `Alchemy::Element` which allows guest user to see.

```ruby
.../alchemy_cms/app/controllers/alchemy/admin/elements_controller.rb
module Alchemy
  module Admin
    class ElementsController < Alchemy::Admin::BaseController
      ...
      authorize_resource class: Alchemy::Element

      def index
        ...
      end
    end
  end
end
```

Below is permission.rb in Alchemy lib which define default roles. Allow guest user to read `Alchemy::Element` and define alchemy_admin_dashboard to allow author access index which author role is been included in admin role

```ruby
.../alchemy_cms/app/lib/alchemy/permission.rb
module Alchemy
  class Permissions
    module GuestUser
      def alchemy_guest_user_rules
        ...

        can :read, Alchemy::Element, Alchemy::Element.available.not_restricted do |e|
          e.public? && !e.restricted? && !e.trashed?
        end

        ...
      end
    end

    module AuthorUser
      ...
      def alchemy_author_rules
        alchemy_member_rules

        # Navigation
        can :index, [:alchemy_admin_dashboard, ...]
      end
    end
  end
end
```

**Proof of works**

Anonymous user is redirected when access admin elements index.

![kapture 2018-10-09 at 14 12 38](https://user-images.githubusercontent.com/14077479/46713967-6a3d8980-cc83-11e8-920e-eef539ac7ee1.gif)
