### PR TITLE
Add default subdomain

### DIFF
--- a/app/controllers/alchemy/admin/pages_controller.rb
+++ b/app/controllers/alchemy/admin/pages_controller.rb
@@ -180,7 +180,7 @@ module Alchemy
         if Config.enable_subdomain_locale
           redirect_to show_page_url(
             urlname: @page.urlname,
-            subdomain: prefix_locale?(@page.language_code) ? page_subdomain(@page.language_code) : nil,
+            subdomain: prefix_locale?(@page.language_code) ? page_subdomain(@page.language_code) : default_page_subdomain,
             host: @page.site.host == "*" ? request.host : @page.site.host
           )
         else

--- a/lib/alchemy/configuration_methods.rb
+++ b/lib/alchemy/configuration_methods.rb
@@ -38,6 +38,11 @@ module Alchemy
       Site.count > 1
     end
 
+    # Override this method in host application in case that the host have default subdomain.
+    def default_page_subdomain
+      raise NotImplementedError if Config.enable_subdomain_locale
+    end
+
     def page_subdomain(locale)
       locale
     end


### PR DESCRIPTION
## What Happened
In case that the host has subdomain by default such as `staging.XXXXX.com`.
When we pick `en` as locale then open the page from the backend, it will respond with `XXXXX.com` with `404` because it ignores the subdomain.